### PR TITLE
Update for Rimworld 1.5 to fix hemogen extraction.

### DIFF
--- a/Source/CompBedConnector.cs
+++ b/Source/CompBedConnector.cs
@@ -157,7 +157,7 @@ public class CompBedConnector : ThingComp {
         {
             var pawn = occupants[o];
             if( !pawn.IsPrisonerOfColony ) continue;
-            if( pawn.guest.interactionMode != PrisonerInteractionModeDefOf.HemogenFarm ) continue;
+			if( !pawn.guest.IsInteractionEnabled (PrisonerInteractionModeDefOf.HemogenFarm) ) continue;
             if( !RecipeDefOf.ExtractHemogenPack.Worker.AvailableOnNow(pawn) ) continue;
             if( pawn.health.hediffSet.HasHediff(HediffDefOf.BloodLoss) ) continue;
 


### PR DESCRIPTION
Rimworld 1.5 changes pawn.guest.interactionMode into a private class, as such the original code to extract hemogen from prisoners no longer works. However 1.5 did add a new way to do it, which is what I've done here.